### PR TITLE
Use release 0.3.0 of boot-tools-deps

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -7,7 +7,7 @@
                             [adzerk/boot-test "RELEASE" :scope "test"]
                             [metosin/boot-alt-test "0.3.2" :scope "test"]
                             [com.stuartsierra/dependency "0.2.0"]
-                            [seancorfield/boot-tools-deps "0.2.3"]])
+                            [seancorfield/boot-tools-deps "0.3.0"]])
 
 (task-options!
  pom {:project     project


### PR DESCRIPTION
The new `Q` option (instead of `-B`) should address the issues you reported. Thank you!